### PR TITLE
Explicitly add issue number

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SQUIDDY_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SQUIDDY_ISSUE_NUMBER: ${{ github.event.issue.number }}
       SQUIDDY_TRELLO_DEVELOPER_PUBLIC_KEY: ${{ secrets.TRELLO_DEVELOPER_PUBLIC_KEY }}
       SQUIDDY_TRELLO_MEMBER_TOKEN: ${{ secrets.TRELLO_MEMBER_TOKEN }}
     steps:

--- a/bin/squiddy
+++ b/bin/squiddy
@@ -15,11 +15,11 @@ puts "GITHUB_REF: #{event.ref}"
 
 case event.type
 when "pull_request"
-  %w(trello_developer_public_key trello_member_token github_access_token).each do |env|
+  %w(trello_developer_public_key trello_member_token github_access_token issue_number).each do |env|
     check_environment_variable(env)
   end
 
-  Squiddy::TrelloPullRequest.run
+  Squiddy::TrelloPullRequest.run(pull_request_number: ENV['SQUIDDY_ISSUE_NUMBER'])
 else
   puts "Nothing to do!"
 end

--- a/lib/squiddy.rb
+++ b/lib/squiddy.rb
@@ -9,12 +9,13 @@ module Squiddy
   # If the Pull Request is in a closed state, then it marks the item as
   # complete
   class TrelloPullRequest
-    def self.run
+    def self.run(pull_request_number:)
+      fail "pull_request_number is nil" if pull_request_number.nil?
+
       event = Squiddy::Event.new
 
       return nil unless event.type == "pull_request"
-
-      pull_request = Squiddy::PullRequest.new(event.repository, event.pull_request_number)
+      pull_request = Squiddy::PullRequest.new(event.repository, pull_request_number)
 
       trello_regex = /https:\/\/trello\.com\/c\/\w+/
 

--- a/spec/lib/squiddy_spec.rb
+++ b/spec/lib/squiddy_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
     end
 
     it 'does nothing' do
-      expect(subject.run).to eq(nil)
+      expect(subject.run(pull_request_number: 1)).to eq(nil)
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
         end
 
         it 'adds an item to a checklist' do
-          subject.run
+          subject.run(pull_request_number: 1)
           expect(trello_checklist).to have_received(:add_item).with(pr_url)
         end
       end
@@ -68,12 +68,12 @@ RSpec.describe Squiddy::TrelloPullRequest do
         end
 
         it 'creates a checklist' do
-          subject.run
+          subject.run(pull_request_number: 1)
           expect(trello_checklist).to have_received(:create_checklist)
         end
 
         it 'adds an item to a checklist' do
-          subject.run
+          subject.run(pull_request_number: 1)
           expect(trello_checklist).to have_received(:add_item).with(pr_url)
         end
       end
@@ -85,7 +85,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
         end
 
         it 'does nothing' do
-          subject.run
+          subject.run(pull_request_number: 1)
           expect(trello_checklist).to_not have_received(:add_item)
         end
       end
@@ -99,7 +99,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
         end
 
         it 'rescues an error' do
-          expect(subject.run).to eq("Squiddy::TrelloChecklist::ChecklistNotFound")
+          expect(subject.run(pull_request_number: 1)).to eq("Squiddy::TrelloChecklist::ChecklistNotFound")
         end
       end
 
@@ -109,7 +109,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
         end
 
         it 'raises an error' do
-          expect { subject.run }.to raise_error(Squiddy::TrelloChecklist::CardNotFound)
+          expect { subject.run(pull_request_number: 1) }.to raise_error(Squiddy::TrelloChecklist::CardNotFound)
         end
       end
     end
@@ -120,7 +120,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
       end
 
       it 'does nothing' do
-        subject.run
+        subject.run(pull_request_number: 1)
         expect(trello_checklist).to_not have_received(:add_item).with(pr_url)
       end
     end
@@ -143,7 +143,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
         end
 
         it 'gets marked as complete' do
-          subject.run
+          subject.run(pull_request_number: 1)
           expect(trello_checklist).to have_received(:mark_item_as_complete).with(pr_url)
         end
       end
@@ -154,7 +154,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
         end
 
         it 'does nothing' do
-          subject.run
+          subject.run(pull_request_number: 1)
           expect(trello_checklist).to_not have_received(:mark_item_as_complete)
         end
       end
@@ -167,7 +167,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
         end
 
         it 'rescues an error' do
-          expect(subject.run).to eq("Squiddy::TrelloChecklist::ChecklistNotFound")
+          expect(subject.run(pull_request_number: 1)).to eq("Squiddy::TrelloChecklist::ChecklistNotFound")
         end
       end
 
@@ -177,7 +177,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
         end
 
         it 'raises an error' do
-          expect { subject.run }.to raise_error(Squiddy::TrelloChecklist::CardNotFound)
+          expect { subject.run(pull_request_number: 1) }.to raise_error(Squiddy::TrelloChecklist::CardNotFound)
         end
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe Squiddy::TrelloPullRequest do
       end
 
       it 'does nothing' do
-        subject.run
+        subject.run(pull_request_number: 1)
         expect(trello_checklist).to_not have_received(:mark_item_as_complete)
       end
     end


### PR DESCRIPTION
When I tested this, I originally used the `GITHUB_REF` environment variable that was passed in by default.

This was fine when a PR was opened or closed, but when merged the ref changed to `refs/heads/master`, which meant that we were not provided with the pull request number to be able to query the GitHub API.

Instead, this depends on passing in the issue number, which is essentially the pull request number (a pull request is a type of issue).
