### PR TITLE
Improve Squiddy's merge bubble commit message

### DIFF
--- a/actions/bubble_merge/git_client.rb
+++ b/actions/bubble_merge/git_client.rb
@@ -84,13 +84,14 @@ module Squiddy
         #{commit_title}
 
         Squiddy-bot has merged the branch #{branch}
-        as requested by #{comment_author} in the PR number #{pr_number}.
+        into #{base_branch} after rebase as requested by #{comment_author}
+        in the PR number ##{pr_number}.
 
         Further details are listed below.
 
         Squiddy out.
 
-        Optional additional details:
+        Triggering comment with optional details:
 
         #{comment}
       MESSAGE

--- a/actions/bubble_merge/git_client.rb
+++ b/actions/bubble_merge/git_client.rb
@@ -76,7 +76,7 @@ module Squiddy
     private
 
     def commit_title
-      "PR no. #{pr_number} merged"
+      "PR ##{pr_number} merged"
     end
 
     def commit_message

--- a/lib/squiddy/git_client.rb
+++ b/lib/squiddy/git_client.rb
@@ -84,13 +84,14 @@ module Squiddy
         #{commit_title}
 
         Squiddy-bot has merged the branch #{branch}
-        as requested by #{comment_author} in the PR number #{pr_number}.
+        into #{base_branch} after rebase as requested by #{comment_author}
+        in the PR number ##{pr_number}.
 
         Further details are listed below.
 
         Squiddy out.
 
-        Optional additional details:
+        Triggering comment with optional details:
 
         #{comment}
       MESSAGE

--- a/lib/squiddy/git_client.rb
+++ b/lib/squiddy/git_client.rb
@@ -76,7 +76,7 @@ module Squiddy
     private
 
     def commit_title
-      "PR no. #{pr_number} merged"
+      "PR ##{pr_number} merged"
     end
 
     def commit_message


### PR DESCRIPTION
Squiddy's Bubble Merge action is almost ready to be used in our main repo.

While we continue testing it thoroughly, we would also like to improve the automatic message
associated with the merge commit by Squiddy.

The top part of the commit message is automatically generated by Squiddy and contains:

- PR number
- branch name
- username of the engineer triggering the merge action

The bottom part of the commit message contains the entire text of the PR comment 
containing the keywords triggering the merge action. See images below.

### PR Comment triggering the action

![PR comment](https://user-images.githubusercontent.com/16342989/88910598-a117d180-d254-11ea-9bb3-9746be17e472.png)

### Commit message

![Merge commit message](https://user-images.githubusercontent.com/16342989/88910138-e7206580-d253-11ea-9285-241b1b63318a.png)

## Feedback

Any suggestions for changes?

