### PR TITLE
Introduce bubble_merge in squiddy repo

### DIFF
--- a/.github/workflows/bubble_merge.yml
+++ b/.github/workflows/bubble_merge.yml
@@ -1,0 +1,37 @@
+name: Bubble Merge
+on:
+  issue_comment:
+    types: [created]
+    branches-ignore:
+      - master
+
+jobs:
+  bubble_merge:
+    name: Bubble Merge
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@squiddy-bot merge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.SQUIDDY_BOT_GITHUB_TOKEN }}
+      - name: Acknowledge Failure
+        if: ${{ failure() }}
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.SQUIDDY_BOT_GITHUB_TOKEN}}
+          script: |
+            await github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Rebase was not possible. Please rebase manually and try again.'
+            })
+      - uses: futurelearn/squiddy/actions/bubble_merge@update-merge-commit-message
+        env:
+          GITHUB_TOKEN: ${{ secrets.SQUIDDY_BOT_GITHUB_TOKEN }}
+          GITHUB_EVENT: ${{ toJson(github.event) }}


### PR DESCRIPTION
So that squiddy can also do bubble merges on its own repo. Is this confusing?

## Description of changes 

Commenting `@squiddy-bot merge` on a PR will perform a bubble merge:

1. rebase the PR from master
2. add PR changes to the HEAD of master
3. merge to master
4. delete PR branch

This will have to be merged into master before the action can be triggered.