### PR TITLE
Use the Alpine Ruby image

### DIFF
--- a/.github/workflows/spec.yaml
+++ b/.github/workflows/spec.yaml
@@ -1,4 +1,4 @@
-name: Test and build
+name: Test
 on: push
 
 jobs:
@@ -6,32 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - id: branch_name
-      run: echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
     - run: bundle exec rspec
-    - uses: docker/build-push-action@v1
-      if: steps.branch_name.outputs.branch != 'master'
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        cache_froms: futurelearn/squiddy:latest
-        repository: futurelearn/squiddy
-        tags: ${{ steps.branch_name.outputs.branch }}
-    - uses: docker/build-push-action@v1
-      if: steps.branch_name.outputs.branch == 'master'
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        cache_froms: futurelearn/squiddy:latest
-        repository: futurelearn/squiddy
-        tags: latest
-    - name: Build gem
-      if: steps.branch_name.outputs.branch == 'master'
-      run: |
-        echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" >> ~/.gem/credentials
-        chmod 0600 ~/.gem/credentials
-        gem build squiddy.gemspec
-        gem push --key github --host https://rubygems.pkg.github.com/futurelearn squiddy-$(cat VERSION).gem || true

--- a/actions/bubble_merge/Dockerfile
+++ b/actions/bubble_merge/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:alpine
 
 LABEL "com.github.actions.name"="Bubble Merge"
 LABEL "com.github.actions.description"="This does a bubble merge!"


### PR DESCRIPTION
The difference in size is ~850MB vs ~50MB; this is because the standard base image is built on a very chunky Ubuntu base image. Given this has to be built each time, it would be much quicker to build it using the much smaller image.
