### PR TITLE
Make deleting branch optional

### DIFF
--- a/actions/bubble_merge/git_client.rb
+++ b/actions/bubble_merge/git_client.rb
@@ -3,7 +3,7 @@ require "json"
 
 module Squiddy
   class GitClient
-    attr_reader :client, :event, :pr
+    attr_reader :client, :event, :pr, :repo
 
     CHECK_STATUSES = %w[queued in_progress completed].freeze
     CHECK_CONCLUSIONS = %w[success failure neutral cancelled skipped timed_out action_required stale].freeze
@@ -16,6 +16,7 @@ module Squiddy
       @client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
       @event = git_event
       @pr = pull_request
+      @repo = repository
     end
 
     def bubble_merge
@@ -59,6 +60,8 @@ module Squiddy
     end
 
     def delete_branch
+      return if repo.delete_branch_on_merge
+
       client.delete_branch(repo_name, branch)
     end
 
@@ -147,6 +150,10 @@ module Squiddy
 
     def pull_request
       client.pull_request(repo_name, pr_number)
+    end
+
+    def repository
+      client.repository(repo_name)
     end
   end
 end

--- a/actions/bubble_merge/git_client.rb
+++ b/actions/bubble_merge/git_client.rb
@@ -3,7 +3,7 @@ require "json"
 
 module Squiddy
   class GitClient
-    attr_reader :client, :event, :pr, :repo
+    attr_reader :client, :event, :pr
 
     CHECK_STATUSES = %w[queued in_progress completed].freeze
     CHECK_CONCLUSIONS = %w[success failure neutral cancelled skipped timed_out action_required stale].freeze
@@ -15,13 +15,12 @@ module Squiddy
 
       @client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
       @event = git_event
-      @repo = repo_name
       @pr = pull_request
     end
 
     def bubble_merge
       if already_merged?
-        client.add_comment(repo, pr_number, 'This PR is already merged.')
+        client.add_comment(repo_name, pr_number, 'This PR is already merged.')
       else
         merge_and_close_pr
       end
@@ -30,7 +29,7 @@ module Squiddy
     private
 
     def already_merged?
-      client.pull_merged?(repo, pr_number)
+      client.pull_merged?(repo_name, pr_number)
     end
 
     def merge_and_close_pr
@@ -43,12 +42,12 @@ module Squiddy
         #### Error message:
         #{e&.message}
       MESSAGE
-      client.add_comment(repo, pr_number, message)
+      client.add_comment(repo_name, pr_number, message)
     end
 
     def merge
       client.merge(
-        repo,
+        repo_name,
         base_branch,
         branch,
         {
@@ -60,11 +59,11 @@ module Squiddy
     end
 
     def delete_branch
-      client.delete_branch(repo, branch)
+      client.delete_branch(repo_name, branch)
     end
 
     def main_sha
-      client.list_commits(repo).last.sha
+      client.list_commits(repo_name).last.sha
     end
 
     def branch
@@ -92,11 +91,11 @@ module Squiddy
     end
 
     def head_commit_checks
-      client.check_suites_for_ref(repo, head_commit_sha)
+      client.check_suites_for_ref(repo_name, head_commit_sha)
     end
 
     def head_commit_sha
-      client.pull_request_commits(repo, pr_number).last.sha
+      client.pull_request_commits(repo_name, pr_number).last.sha
     end
 
     def comment_author
@@ -147,7 +146,7 @@ module Squiddy
     end
 
     def pull_request
-      client.pull_request(repo, pr_number)
+      client.pull_request(repo_name, pr_number)
     end
   end
 end


### PR DESCRIPTION
Some repos have the "delete_branch_on_merge" option turned on
which means once a PR merge is successful, the branch will be
deleted automatically.

After [improving error messages][2] for squiddy [we can see][1] that when
it attempts to delete the merged branch, it sometimes gets an 
error back (which was previously silent):

```
Error message:
DELETE https://api.github.com/repos/futurelearn/futurelearn/git/refs/heads/jrwc-make-cookie-banner-feature-flag-apply-in-dev: 
422 - Reference does not exist // See: https://docs.github.com/rest/reference/git#delete-a-reference
```

Let's check the repo for this setting before attempting to delete the branch.

Tested here:

- with `delete_branch_on_merge: true`: https://github.com/futurelearn/test-github-actions/pull/84
- with `delete_branch_on_merge: false`: https://github.com/futurelearn/test-github-actions/pull/85

[1]: https://github.com/futurelearn/futurelearn/pull/7886#issuecomment-756224350
[2]: https://github.com/futurelearn/squiddy/commit/3d6d5438880a07bf2123ce83d0f8b9386ad74e7f#diff-c7c35def7d2e47d24d0dbbc1bdf94f5423a15a63cee0a0062829c291ea12fe5bR24