### PR TITLE
Move branch name at the top of the commit message

### DIFF
--- a/actions/bubble_merge/git_client.rb
+++ b/actions/bubble_merge/git_client.rb
@@ -114,7 +114,7 @@ module Squiddy
     end
 
     def commit_title
-      "PR ##{pr_number} merged"
+      "Merge branch '#{branch}' into #{base_branch}"
     end
 
     def optional_message
@@ -127,7 +127,7 @@ module Squiddy
 
         Squiddy-bot has merged the branch #{branch}
         into #{base_branch} after rebase as requested by #{comment_author}
-        in the PR ##{pr_number}.
+        in PR ##{pr_number}.
 
         Further details are listed below.
 

--- a/spec/actions/bubble_merge/git_client_spec.rb
+++ b/spec/actions/bubble_merge/git_client_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe Squiddy::GitClient do
   context '#bubble_merge' do
     let(:commit_message) {
       <<~MESSAGE
-        PR #test-pr-number merged
+        Merge branch 'test-branch' into test-base-branch
 
         Squiddy-bot has merged the branch test-branch
         into test-base-branch after rebase as requested by test-user
-        in the PR #test-pr-number.
+        in PR #test-pr-number.
 
         Further details are listed below.
 


### PR DESCRIPTION
Now that we've moved deployments to github actions, we'd like to
make it easier to find the corresponding deployment action for our
recently merged PR.

Let's put the branch name first in the merge commit title so we
can filter by it.