### PR TITLE
Update bubble_merge.yml

### DIFF
--- a/.github/workflows/bubble_merge.yml
+++ b/.github/workflows/bubble_merge.yml
@@ -1,7 +1,7 @@
 name: Bubble Merge
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
     branches-ignore:
       - master
 


### PR DESCRIPTION
Currently when a comment is edited, github actions will not check to see if the edited comment contains "@squiddybot merge".

This means that if you make a typo and edit your comment, nothing will happen, which is a bit counterintuitive. 

This commit extends bubble merge to edited comments. If the comment does not contain "@squiddybot merge" the workflow is triggered, but the job is skipped, the same as when adding a new comment.

Previously: https://github.com/futurelearn/futurelearn/pull/11725