### PR TITLE
Migrate Bubble Merge workflow to a central reusable workflow

### DIFF
--- a/.github/workflows/bubble_merge.yml
+++ b/.github/workflows/bubble_merge.yml
@@ -2,36 +2,11 @@ name: Bubble Merge
 on:
   issue_comment:
     types: [created, edited]
-    branches-ignore:
-      - master
 
 jobs:
   bubble_merge:
-    name: Bubble Merge
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@squiddy-bot merge')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the latest code
-        uses: actions/checkout@main
-        with:
-          fetch-depth: 0
-      - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.6
-        env:
-          GITHUB_TOKEN: ${{ secrets.SQUIDDY_BOT_GITHUB_TOKEN }}
-      - name: Acknowledge Failure
-        if: ${{ failure() }}
-        uses: actions/github-script@0.9.0
-        with:
-          github-token: ${{secrets.SQUIDDY_BOT_GITHUB_TOKEN}}
-          script: |
-            await github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Rebase was not possible. Please rebase manually and try again.'
-            })
-      - uses: futurelearn/squiddy/actions/bubble_merge@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.SQUIDDY_BOT_GITHUB_TOKEN }}
-          GITHUB_EVENT: ${{ toJson(github.event) }}
+    name: Bubble Merge
+    uses: futurelearn/actions/.github/workflows/bubble_merge.yaml@main
+    secrets:
+      SQUIDDY_BOT_GITHUB_TOKEN: ${{ secrets.SQUIDDY_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
[Trello](https://trello.com/c/kmLaN8jU/3723-fix-squiddy-bots-ability-to-merge-github-actions-changes)

It is now possible to reference reusable workflows in other private repositories owned by the same organization[1]

A central reusable workflow for Bubble Merge has been created in the futurelearn/actions repo[2] and now we will reference that from our other repos that want to use squiddy-bot to perform bubble merges of pull requests.

By centralising the workflow, if any changes are required to it in the future, we only need to update it in one place for it to apply in all repos that use it.

The `branches-ignore` key has been removed as that is not valid for `issue-comment` type triggers:

```
actionlint .github/workflows/bubble_merge.yml
.github/workflows/bubble_merge.yml:5:5: "branches-ignore" filter is not available for issue_comment event. it is only for push,
pull_request, pull_request_target, workflow_run events [events]
```

[1]https://github.blog/changelog/2022-12-14-github-actions-sharing-actions-and-reusable-workflows-from-private-repositories-is-now-ga/ [2]https://github.com/futurelearn/actions/commit/2e70636c43fb1a0e999489a3a7d84dec0864de84